### PR TITLE
Fix NPE in addInformation of Location Chip

### DIFF
--- a/src/main/java/remoteio/common/item/ItemLocationChip.java
+++ b/src/main/java/remoteio/common/item/ItemLocationChip.java
@@ -32,7 +32,10 @@ public final class ItemLocationChip extends Item {
     public void addInformation(ItemStack stack, EntityPlayer player, List<String> list, boolean debug) {
         DimensionalCoords coords = ItemLocationChip.getCoordinates(stack);
         if (coords != null) {
-            list.add("Dimension: " + DimensionManager.getProvider(coords.dimensionID).getDimensionName());
+            if(DimensionManager.getWorld(coords.dimensionID) != null)
+                list.add("Dimension: " + DimensionManager.getProvider(coords.dimensionID).getDimensionName());
+            else
+                list.add("Dimension: " + coords.dimensionID);
             list.add("X: " + coords.x + " Y: " + coords.y + " Z: " + coords.z);
         }
     }

--- a/src/main/java/remoteio/common/item/ItemLocationChip.java
+++ b/src/main/java/remoteio/common/item/ItemLocationChip.java
@@ -32,10 +32,9 @@ public final class ItemLocationChip extends Item {
     public void addInformation(ItemStack stack, EntityPlayer player, List<String> list, boolean debug) {
         DimensionalCoords coords = ItemLocationChip.getCoordinates(stack);
         if (coords != null) {
-            if(DimensionManager.getWorld(coords.dimensionID) != null)
+            if (DimensionManager.getWorld(coords.dimensionID) != null)
                 list.add("Dimension: " + DimensionManager.getProvider(coords.dimensionID).getDimensionName());
-            else
-                list.add("Dimension: " + coords.dimensionID);
+            else list.add("Dimension: " + coords.dimensionID);
             list.add("X: " + coords.x + " Y: " + coords.y + " Z: " + coords.z);
         }
     }


### PR DESCRIPTION
Location Chip will get dimension name by dim ID on client to show it in tooltips.
![2024-11-24_18 26 54](https://github.com/user-attachments/assets/a438bf52-0ed2-4625-99e1-3fc188965d90)

However when such dimension is missing(or present on dedicated server, but absent on client) it will generate an NPE.
Normally the NPE is caught by GuiContainerManager.itemDisplayNameMultiline and ignored (and makes its name 'Unnamed').
![2024-11-24_17 59 57](https://github.com/user-attachments/assets/24eeef49-0123-4616-aee1-4caaef486bfe)

But if player open a GT machine or anything uses ModularUI with this chip in inventory, it's unguarded and crashes the client.
```
java.lang.NullPointerException
    at net.minecraftforge.common.DimensionManager.getProvider(DimensionManager.java:155)
    at remoteio.common.item.ItemLocationChip.addInformation(ItemLocationChip.java:35)
    at net.minecraft.item.ItemStack.getTooltip(ItemStack.java:525)
    at com.gtnewhorizons.modularui.api.drawable.GuiHelper.getItemTooltip(GuiHelper.java:458)
    at com.gtnewhorizons.modularui.common.internal.wrapper.ModularGui.renderToolTip(ModularGui.java:422)
    at com.gtnewhorizons.modularui.common.internal.wrapper.ModularGui.drawGuiContainerForegroundLayer(ModularGui.java:299)
    at com.gtnewhorizons.modularui.common.internal.wrapper.ModularGui.drawScreen(ModularGui.java:157)
    at net.minecraft.client.renderer.EntityRenderer.updateCameraAndRender(EntityRenderer.java:1061)
    at net.minecraft.client.Minecraft.runGameLoop(Minecraft.java:1001)
    at net.minecraft.client.Minecraft.run(Minecraft.java:6110)
    at net.minecraft.client.main.Main.main(SourceFile:148)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at net.minecraft.launchwrapper.Launch.launch(Launch.java:135)
    at net.minecraft.launchwrapper.Launch.main(Launch.java:28)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(Unknown Source)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(Unknown Source)
    at java.lang.reflect.Method.invoke(Unknown Source)
    at org.multimc.onesix.OneSixLauncher.launchWithMainClass(OneSixLauncher.java:243)
    at org.multimc.onesix.OneSixLauncher.launch(OneSixLauncher.java:278)
    at org.multimc.EntryPoint.listen(EntryPoint.java:143)
    at org.multimc.EntryPoint.main(EntryPoint.java:34)

```


This PR checks if the world exists on client, and show dim ID instead of throwing NPE if not found.
![2024-11-24_18 15 02](https://github.com/user-attachments/assets/a167cd44-9009-4f7b-9ed1-31a57be93326)
