### PR TITLE
Fix TileRemoteInterface implementation

### DIFF
--- a/src/main/java/remoteio/common/tile/TileRemoteInterface.java
+++ b/src/main/java/remoteio/common/tile/TileRemoteInterface.java
@@ -1067,7 +1067,7 @@ public class TileRemoteInterface extends TileIOCore
     @Optional.Method(modid = DependencyInfo.ModIds.AE2)
     public EnumSet<GridFlags> getFlags() {
         IGridBlock gridBlock = (IGridBlock) getTransferImplementation(IGridBlock.class);
-        return gridBlock != null ? getFlags() : EnumSet.noneOf(GridFlags.class);
+        return gridBlock != null ? gridBlock.getFlags() : EnumSet.noneOf(GridFlags.class);
     }
 
     @Override
@@ -1127,7 +1127,7 @@ public class TileRemoteInterface extends TileIOCore
     @Optional.Method(modid = DependencyInfo.ModIds.AE2)
     public ItemStack getMachineRepresentation() {
         IGridBlock gridBlock = (IGridBlock) getTransferImplementation(IGridBlock.class);
-        return gridBlock != null ? getMachineRepresentation() : new ItemStack(this.blockType);
+        return gridBlock != null ? gridBlock.getMachineRepresentation() : new ItemStack(this.blockType);
     }
 
     /* END IMPLEMENTATIONS */


### PR DESCRIPTION
The bug is:
1.Place a RIO Interface block, and insert an AE Network Chip
2.Link the RIO Interface to a Wireless Connector(from ae2stuff)
3.game crash
[crash-2024-11-24_15.04.12-server.txt](https://github.com/user-attachments/files/17893925/crash-2024-11-24_15.04.12-server.txt)

And this is caused by AE Chip part of RIO Interface not being properly implemented.
other chips(like fluid/item trans chip, EU trans chip) has code like

```
public ReturnType getXX(){
        IInterfaceXXXX  instance= (IInterfaceXXXX) getTransferImplementation(IInterfaceXXXX.class);//get target
        return instance!= null ? instance.getXX() :EMPTY;//if present, call getXX    if not, return an empty placeholder
}
```
However, AE Chip code goes like:
```
public EnumSet<GridFlags> getFlags() {
        IGridBlock gridBlock = (IGridBlock) getTransferImplementation(IGridBlock.class);
        return gridBlock != null ? /*   recursive call!!!receiver is not gridBlock! */getFlags() : EnumSet.noneOf(GridFlags.class);
    
}
```


Normally, these two functions are not called, but if bound to Wireless Connector, these methods are called for some reason and game crashes.
By the way, I checked history of the .java file, it seems that these two methods are buggy since the mod has been migrated to 1.7.10 by its original author.


Screenshot: Not crashing the game. This is impossible before the PR.
![2024-11-24_23 36 59](https://github.com/user-attachments/assets/8bfea6fa-bbf2-41da-a5dc-9332efb490bc)
