### PR TITLE
Add Localizations

### DIFF
--- a/src/main/resources/assets/remoteio/lang/en_US.lang
+++ b/src/main/resources/assets/remoteio/lang/en_US.lang
@@ -60,6 +60,7 @@ chat.target.loop=You cannot link an interface block with another interface block
 # Item
 item.blank_plate.name=Blank Plate
 item.chip.location.name=Location Chip
+item.chip.transfer.name=Transfer Chip
 item.chip.transfer.item.name=Item Transfer Chip
 item.chip.transfer.fluid.name=Fluid Transfer Chip
 item.chip.transfer.essentia.name=Essentia Transfer Chip
@@ -68,6 +69,7 @@ item.chip.transfer.energy_mj.name=MJ Energy Transfer Chip
 item.chip.transfer.energy_rf.name=RF Energy Transfer Chip
 item.chip.transfer.network_ae.name=AE2 Network Transfer Chip
 item.chip.transfer.redstone.name=Redstone Transfer Chip
+item.chip.upgrade.name=Remote Upgrade
 item.chip.upgrade.remote_camo.name=Remote Camouflage Upgrade
 item.chip.upgrade.remote_access.name=Remote Access Upgrade
 item.chip.upgrade.simple_camo.name=Simple Camouflage Upgrade
@@ -81,6 +83,7 @@ item.linker.name=Linker
 # Block
 tile.remote_interface.name=Remote Interface
 tile.remote_inventory.name=Remote Inventory
+tile.machine.name=Machine
 tile.machine.reservoir.name=Water Reservoir
 tile.machine.heater.name=Lava Heater
 tile.intelligentWorkbench.name=Intelligent Workbench


### PR DESCRIPTION
This adds some missing localizations for unlocalized names returned by the ItemStack-insensitive version of `Item.getUnlocalizedName()`.
Relevant for the Item/Block stats introduced in https://github.com/GTNewHorizons/Hodgepodge/pull/398.